### PR TITLE
Fix menu not cleared outside content area

### DIFF
--- a/src/gfx/drivers/miyoomini/sdl_miyoomini_gfx.c
+++ b/src/gfx/drivers/miyoomini/sdl_miyoomini_gfx.c
@@ -938,6 +938,7 @@ static bool sdl_miyoomini_gfx_frame(void *data, const void *frame,
       if (unlikely(vid->was_in_menu)) {
          sdl_miyoomini_clear_border(fb_addr, vid->video_x, vid->video_y, vid->video_w, vid->video_h);
          vid->was_in_menu = false;
+         stOpt.eRotate = vid->rotate;
       }
       /* Update video mode if width/height have changed */
       if (unlikely( (vid->content_width  != width ) ||
@@ -951,10 +952,12 @@ static bool sdl_miyoomini_gfx_frame(void *data, const void *frame,
       /* HW Blit GFX surface to Framebuffer and Flip */
       GFX_UpdateRect(vid->screen, vid->video_x, vid->video_y, vid->video_w, vid->video_h);
    } else {
+      if (!vid->was_in_menu) {
+         vid->was_in_menu = true;
+         stOpt.eRotate = E_MI_GFX_ROTATE_180;
+      }
       SDL_SoftStretch(vid->menuscreen_rgui, NULL, vid->menuscreen, rgui_menu_stretch ? NULL : &rgui_menu_dest_rect);
-      stOpt.eRotate = E_MI_GFX_ROTATE_180;
       GFX_Flip(vid->menuscreen);
-      stOpt.eRotate = vid->rotate;
    }
    return true;
 }


### PR DESCRIPTION
When closing the menu, sdl_miyoomini_clear_border is not called. When the menu renders outside of the content area (e.g. with stretched menu and non 4:3 content), the menu will remain on the framebuffer.

There is an existing check (probably from dingux) that checks if the menu is closed and `was_in_menu` is set (meaning this is the first frame where the menu is closed), we clear the border. However, the miyoomini version does not set `was_in_menu`, so that logic was not triggered.

By saving `was_in_menu`, we can also only set the stOpt.eRotate on the first frame that the menu opens, and the first frame after the menu is closed.